### PR TITLE
Fix default export typos

### DIFF
--- a/src/Components/atoms/PasswordToggle/index.js
+++ b/src/Components/atoms/PasswordToggle/index.js
@@ -1,1 +1,1 @@
-export { defaul } from './PasswordToggle'
+export { default } from './PasswordToggle'

--- a/src/Components/molecules/AvatarSelector/index.js
+++ b/src/Components/molecules/AvatarSelector/index.js
@@ -1,1 +1,1 @@
-export { defaul } from './AvatarSelector'
+export { default } from './AvatarSelector'


### PR DESCRIPTION
## Summary
- correct `export { default }` statements in `PasswordToggle` and `AvatarSelector`

