### PR TITLE
Extract routing to `appRouter` and switch to `RouterProvider`; move auth guards out of `App`

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,39 +1,15 @@
-import { useState, useContext, useCallback } from 'react'
-import { Route, Routes, Navigate } from 'react-router-dom'
-import { AuthContext } from './context/AuthContext/AuthContext'
+import { useState, useCallback } from 'react'
+import { Outlet } from 'react-router-dom'
 import Navbar from './Components/organisms/Navbar/Navbar'
 import Footer from './Components/organisms/Footer/Footer'
-import ProfilePage from './pages/ProfilePage/ProfilePage'
 import AuthCard from './Components/organisms/AuthCard/AuthCard'
-import DashboardPage from './pages/DashboardPage'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
-
-/**
- * Ruta privada que solo permite el acceso si el usuario ha iniciado sesión.
- * - Muestra un loader mientras se verifica la sesión.
- * - Redirige a la raíz si no hay sesión activa.
- */
-const PrivateRoute = ({ children }) => {
-  const { isLoggedIn, checking } = useContext(AuthContext)
-
-  if (checking) {
-    return (
-      <div className="flex justify-center items-center min-h-screen">
-        <span className="animate-spin border-t-4 border-primary-dark h-10 w-10 rounded-full"></span>
-      </div>
-    )
-  }
-
-  return isLoggedIn ? children : <Navigate to="/" replace={true} />
-}
 
 const App = () => {
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false)
   const [activeForm, setActiveForm] = useState('login')
   const [dropdownHeight, setDropdownHeight] = useState(0)
-  const { isLoggedIn } = useContext(AuthContext)
-
   const openAuthModal = useCallback((formType) => {
     setActiveForm(formType)
     setIsAuthModalOpen(true)
@@ -56,42 +32,7 @@ const App = () => {
           dropdownHeight > 0 ? 'mt-10' : ''
         }`}
       >
-        <Routes>
-          <Route
-            path="/"
-            element={
-              isLoggedIn ? (
-                <Navigate to="/dashboard" replace />
-              ) : (
-                <div>Inicio</div>
-              )
-            }
-          />
-          <Route
-            path="/profile"
-            element={
-              <PrivateRoute>
-                <ProfilePage />
-              </PrivateRoute>
-            }
-          />
-          <Route
-            path="/dashboard"
-            element={
-              <PrivateRoute>
-                <DashboardPage />
-              </PrivateRoute>
-            }
-          />
-          <Route
-            path="*"
-            element={
-              <div className="text-center mt-10 text-lg font-medium">
-                Página no encontrada
-              </div>
-            }
-          />
-        </Routes>
+        <Outlet />
       </main>
 
       <Footer />

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,19 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import App from './App.jsx'
 import './index.css'
-import AuthProvider from './context/AuthContext/AuthProvider'
-import { BrowserRouter } from 'react-router-dom'
+import { RouterProvider } from 'react-router-dom'
+import { appRouter } from './router/appRouter'
 
 try {
   const root = createRoot(document.getElementById('root'))
   root.render(
     <StrictMode>
-      <BrowserRouter>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </BrowserRouter>
+      <RouterProvider router={appRouter} />
     </StrictMode>
   )
 } catch (error) {

--- a/src/router/appRouter.jsx
+++ b/src/router/appRouter.jsx
@@ -1,0 +1,101 @@
+import { Navigate, createBrowserRouter } from 'react-router-dom'
+import App from '../App'
+import ProfilePage from '../pages/ProfilePage/ProfilePage'
+import DashboardPage from '../pages/DashboardPage'
+import AuthProvider from '../context/AuthContext/AuthProvider'
+import { AuthContext } from '../context/AuthContext/AuthContext'
+import { useContext } from 'react'
+
+/**
+ * Renderiza una pantalla de carga mientras se valida la sesión.
+ * @returns {JSX.Element} Indicador visual de carga de autenticación.
+ */
+const AuthLoader = () => (
+  <div className="flex justify-center items-center min-h-screen">
+    <span className="animate-spin border-t-4 border-primary-dark h-10 w-10 rounded-full"></span>
+  </div>
+)
+
+/**
+ * Protege rutas privadas en función del estado de autenticación global.
+ * @param {{ children: React.ReactNode }} props Contenido protegido.
+ * @returns {JSX.Element} Ruta protegida o redirección al inicio.
+ */
+const PrivateRoute = ({ children }) => {
+  const { isLoggedIn, checking } = useContext(AuthContext)
+
+  if (checking) {
+    return <AuthLoader />
+  }
+
+  if (!isLoggedIn) {
+    return <Navigate to="/" replace />
+  }
+
+  return children
+}
+
+/**
+ * Controla el comportamiento de la ruta raíz según el estado de sesión.
+ * @returns {JSX.Element} Redirección al dashboard o vista pública de inicio.
+ */
+const HomeRoute = () => {
+  const { isLoggedIn, checking } = useContext(AuthContext)
+
+  if (checking) {
+    return <AuthLoader />
+  }
+
+  if (isLoggedIn) {
+    return <Navigate to="/dashboard" replace />
+  }
+
+  return <div>Inicio</div>
+}
+
+/**
+ * Agrupa proveedores globales que deben envolver todas las rutas.
+ * @returns {JSX.Element} Árbol de aplicación con contexto de autenticación.
+ */
+const AppProviders = () => (
+  <AuthProvider>
+    <App />
+  </AuthProvider>
+)
+
+export const appRouter = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppProviders />,
+    children: [
+      {
+        index: true,
+        element: <HomeRoute />,
+      },
+      {
+        path: 'profile',
+        element: (
+          <PrivateRoute>
+            <ProfilePage />
+          </PrivateRoute>
+        ),
+      },
+      {
+        path: 'dashboard',
+        element: (
+          <PrivateRoute>
+            <DashboardPage />
+          </PrivateRoute>
+        ),
+      },
+      {
+        path: '*',
+        element: (
+          <div className="text-center mt-10 text-lg font-medium">
+            Página no encontrada
+          </div>
+        ),
+      },
+    ],
+  },
+])


### PR DESCRIPTION
### Motivation

- Centralize route configuration and providers so the router and auth guards live outside the `App` presentation component.
- Simplify `App` to only render layout and leave route rendering to React Router's nested routes (`Outlet`).
- Prepare the application for `createBrowserRouter`/`RouterProvider` usage and clearer separation of concerns.

### Description

- Moved route definitions and authentication logic into a new `src/router/appRouter.jsx` which exports `appRouter` created with `createBrowserRouter` and includes `AuthLoader`, `PrivateRoute`, `HomeRoute`, and `AppProviders` helpers.
- Replaced inline `Routes`/`Route` usage in `src/App.jsx` with an `Outlet` and removed direct `AuthContext` usage from `App` so it only provides layout (`Navbar`, `Footer`, `AuthCard`, `ToastContainer`).
- Updated `src/main.jsx` to use `RouterProvider` and `appRouter` instead of `BrowserRouter` and moved the `AuthProvider` into the router via `AppProviders`.
- Added new file `src/router/appRouter.jsx` and adjusted imports in `App` and `main.jsx` accordingly.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0e3047244832084929ade088ca4b7)