### PR TITLE
Always validate session with backend (handle HttpOnly cookies)

### DIFF
--- a/src/services/api/authController.js
+++ b/src/services/api/authController.js
@@ -43,13 +43,9 @@ export const login = async (email, password) => {
  */
 export const getUserSession = async () => {
   try {
-    // Si no hay cookies en el cliente, no llamar al backend
-    if (!document.cookie.includes('token')) {
-      console.warn(
-        'No hay token en las cookies, evitando solicitud innecesaria.'
-      )
-      return null
-    }
+    // Validar sesión siempre contra el backend.
+    // Esto evita falsos negativos cuando la cookie de sesión es HttpOnly
+    // y, por diseño de seguridad, no puede leerse desde document.cookie.
 
     const response = await api.get('/auth/validate-token', {
       withCredentials: true,


### PR DESCRIPTION
### Motivation
- Ensure session checks do not produce false negatives when the session cookie is `HttpOnly` by validating the session against the backend rather than reading `document.cookie` locally.

### Description
- Update `getUserSession` to always call the `'/auth/validate-token'` endpoint with `withCredentials: true`, remove the client-side `document.cookie` check, and return `null` on HTTP 401 without triggering a logout.

### Testing
- Ran the existing automated test suite and CI checks against the modified authentication logic and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0e7faa6388320a4a0fbe6e3aa5afd)