### PR TITLE
Manejar cancelaciones por timeout en checkSession (AbortController)

### DIFF
--- a/src/context/AuthContext/AuthProvider.jsx
+++ b/src/context/AuthContext/AuthProvider.jsx
@@ -11,6 +11,16 @@ const AuthProvider = ({ children }) => {
   const navigate = useNavigate()
 
   const API_BASE = import.meta.env.VITE_API_BASE
+  const ABORT_REASON = 'Validación de sesión cancelada por timeout.'
+
+  // Identifica de forma consistente los abortos de peticiones para tratarlos como cancelaciones esperadas.
+  const isAbortError = (error) => {
+    return (
+      error?.name === 'AbortError' ||
+      error?.message === ABORT_REASON ||
+      error === ABORT_REASON
+    )
+  }
 
   const login = (userData) => {
     setUser({ ...userData })
@@ -37,10 +47,10 @@ const AuthProvider = ({ children }) => {
   }, [navigate])
 
   const checkSession = async () => {
-    try {
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 7000)
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(ABORT_REASON), 7000)
 
+    try {
       const response = await fetch(
         `${API_BASE.replace(/\/$/, '')}/auth/refresh-token`,
         {
@@ -49,8 +59,6 @@ const AuthProvider = ({ children }) => {
           signal: controller.signal,
         }
       )
-
-      clearTimeout(timeout)
 
       if (!response.ok) {
         setUser(null)
@@ -62,11 +70,16 @@ const AuthProvider = ({ children }) => {
       setUser(data.user)
       setIsLoggedIn(true)
     } catch (err) {
+      if (isAbortError(err)) {
+        return
+      }
+
       console.error('Error al validar sesión:', err)
       setError('No se pudo conectar con el servidor. Intenta nuevamente.')
       setUser(null)
       setIsLoggedIn(false)
     } finally {
+      clearTimeout(timeoutId)
       setChecking(false)
     }
   }


### PR DESCRIPTION
### Motivation
- Evitar el mensaje genérico "signal is aborted without reason" cuando la comprobación de sesión se cancela por timeout. 
- Tratar abortos intencionales como cancelaciones esperadas en vez de errores de conexión que muestran un mensaje al usuario.
- Asegurar la limpieza del temporizador asociado a la petición para evitar fugas de timers.

### Description
- Añade la constante `ABORT_REASON` con un motivo legible para pasar a `controller.abort(...)` durante la validación de sesión en `checkSession`.
- Introduce la función `isAbortError` que identifica cancelaciones por nombre o por el motivo proporcionado para tratarlas de forma controlada.
- Mueve la creación de `AbortController` y el `setTimeout` fuera del `try`, usa `timeoutId` y llama a `controller.abort(ABORT_REASON)` para que el `AbortError` sea informativo.
- Limpia el temporizador con `clearTimeout(timeoutId)` en el bloque `finally` y evita registrar errores cuando la excepción es un aborto reconocible; los cambios aplicados en `src/context/AuthContext/AuthProvider.jsx`.

### Testing
- Ejecutado `npm run build` y la compilación de `vite` finalizó correctamente sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ff838114832084fa1f3da424442a)