### PR TITLE
AuthProvider: make session check resilient to timeouts and missing API base

### DIFF
--- a/src/context/AuthContext/AuthProvider.jsx
+++ b/src/context/AuthContext/AuthProvider.jsx
@@ -15,7 +15,11 @@ const AuthProvider = ({ children }) => {
 
   // Normaliza la detección de cancelaciones para que los abortos esperados no rompan el flujo de autenticación.
   const isAbortError = (error) => {
-    return error?.name === 'AbortError' || error === ABORT_REASON
+    return (
+      error?.name === 'AbortError' ||
+      error?.message === ABORT_REASON ||
+      error === ABORT_REASON
+    )
   }
 
   const login = (userData) => {

--- a/src/context/AuthContext/AuthProvider.jsx
+++ b/src/context/AuthContext/AuthProvider.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import { login as loginRequest, logout } from '@/services/api/authController'
+import { logout } from '@/services/api/authController'
 import { AuthContext } from './AuthContext'
 import { useNavigate } from 'react-router-dom'
 
@@ -11,6 +11,12 @@ const AuthProvider = ({ children }) => {
   const navigate = useNavigate()
 
   const API_BASE = import.meta.env.VITE_API_BASE
+  const ABORT_REASON = 'Validación de sesión cancelada por timeout.'
+
+  // Normaliza la detección de cancelaciones para que los abortos esperados no rompan el flujo de autenticación.
+  const isAbortError = (error) => {
+    return error?.name === 'AbortError' || error === ABORT_REASON
+  }
 
   const login = (userData) => {
     setUser({ ...userData })
@@ -36,37 +42,61 @@ const AuthProvider = ({ children }) => {
     }
   }, [navigate])
 
+  // Verifica la sesión inicial sin bloquear la UI de login si el backend falla temporalmente.
   const checkSession = async () => {
+    // Crea un timeout controlado para evitar requests colgadas durante la validación de sesión.
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(ABORT_REASON), 7000)
+
     try {
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 7000)
+      if (!API_BASE) {
+        console.log('[AuthProvider] VITE_API_BASE no está definido, se omite checkSession.')
+        setUser(null)
+        setIsLoggedIn(false)
+        return
+      }
 
-      const response = await fetch(
-        `${API_BASE.replace(/\/$/, '')}/auth/refresh-token`,
-        {
-          method: 'POST',
-          credentials: 'include',
-          signal: controller.signal,
-        }
-      )
+      const refreshUrl = `${API_BASE.replace(/\/$/, '')}/auth/refresh-token`
+      console.log('[AuthProvider] Iniciando checkSession:', { refreshUrl })
 
-      clearTimeout(timeout)
+      const response = await fetch(refreshUrl, {
+        method: 'POST',
+        credentials: 'include',
+        signal: controller.signal,
+      })
+
+      console.log('[AuthProvider] checkSession status:', response.status)
 
       if (!response.ok) {
+        console.log('[AuthProvider] Sesión no válida o no existente; se mantiene usuario deslogueado.')
         setUser(null)
         setIsLoggedIn(false)
         return
       }
 
       const data = await response.json()
+      console.log('[AuthProvider] checkSession OK, usuario recuperado:', data?.user)
+      setError(null)
       setUser(data.user)
       setIsLoggedIn(true)
     } catch (err) {
-      console.error('Error al validar sesión:', err)
-      setError('No se pudo conectar con el servidor. Intenta nuevamente.')
+      if (isAbortError(err)) {
+        console.log('[AuthProvider] checkSession abortado de forma esperada:', ABORT_REASON)
+        return
+      }
+
+      console.error('[AuthProvider] Error al validar sesión:', {
+        name: err?.name,
+        message: err?.message,
+        stack: err?.stack,
+      })
+
+      // No bloqueamos el modal de auth con una pantalla de error global: degradamos a estado deslogueado.
+      setError(null)
       setUser(null)
       setIsLoggedIn(false)
     } finally {
+      clearTimeout(timeoutId)
       setChecking(false)
     }
   }


### PR DESCRIPTION
### Motivation
- Hacer que la validación de sesión inicial sea más robusta frente a timeouts, abortos esperados y ausencia de la variable `VITE_API_BASE`, y evitar que fallos temporales bloqueen la UI de autenticación.
- Normalizar el tratamiento de abortos para que no se muestren errores globales indeseados durante la comprobación de sesión.
- Añadir logs diagnósticos para facilitar la depuración de problemas de refresh-token.

### Description
- Eliminada la importación no usada `login` y se añadió la constante `ABORT_REASON` y el helper `isAbortError` para detectar abortos personalizados y `AbortError` estándar.
- `checkSession` ahora crea un `AbortController` con timeout controlado (`timeoutId`) que aborta con la razón personalizada, construye `refreshUrl` a partir de `VITE_API_BASE`, y sale temprano si `VITE_API_BASE` no está definido.
- Se añadieron console logs para el inicio, el estado HTTP y la información del usuario recuperado, se maneja `response.ok` para mantener al usuario deslogueado en respuestas no válidas, y se degradan errores de red a estado deslogueado sin bloquear el modal de login (`setError(null)`).
- En el bloque `catch` se filtran abortos esperados usando `isAbortError`, y en `finally` se limpia `timeoutId` y se actualiza `checking`; además `checkSession` se lanza con un retraso de 150ms desde el `useEffect`.

### Testing
- No se ejecutaron pruebas automatizadas sobre estos cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ff838114832084fa1f3da424442a)