### PR TITLE
Fix auth connectivity timeouts and improve session validation

### DIFF
--- a/src/context/AuthContext/AuthProvider.jsx
+++ b/src/context/AuthContext/AuthProvider.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { login as loginRequest, logout } from '@/services/api/authController'
 import { AuthContext } from './AuthContext'
 import { useNavigate } from 'react-router-dom'
+import api from '@/services/api/api'
 
 const AuthProvider = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
@@ -11,6 +12,7 @@ const AuthProvider = ({ children }) => {
   const navigate = useNavigate()
 
   const API_BASE = import.meta.env.VITE_API_BASE
+  const SESSION_TIMEOUT_MS = Number(import.meta.env.VITE_SESSION_TIMEOUT_MS) || 25000
   const ABORT_REASON = 'Validación de sesión cancelada por timeout.'
 
   // Normaliza la detección de cancelaciones para que los abortos esperados no rompan el flujo de autenticación.
@@ -50,7 +52,10 @@ const AuthProvider = ({ children }) => {
   const checkSession = async () => {
     // Crea un timeout controlado para evitar requests colgadas durante la validación de sesión.
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(ABORT_REASON), 7000)
+    const timeoutId = setTimeout(
+      () => controller.abort(ABORT_REASON),
+      SESSION_TIMEOUT_MS
+    )
 
     try {
       if (!API_BASE) {
@@ -62,18 +67,24 @@ const AuthProvider = ({ children }) => {
         return
       }
 
-      const refreshUrl = `${API_BASE.replace(/\/$/, '')}/auth/refresh-token`
-      console.log('[AuthProvider] Iniciando checkSession:', { refreshUrl })
-
-      const response = await fetch(refreshUrl, {
-        method: 'POST',
-        credentials: 'include',
-        signal: controller.signal,
+      const refreshUrl = '/auth/refresh-token'
+      console.log('[AuthProvider] Iniciando checkSession:', {
+        refreshUrl,
+        timeout: SESSION_TIMEOUT_MS,
       })
+
+      const response = await api.post(
+        refreshUrl,
+        {},
+        {
+          signal: controller.signal,
+          withCredentials: true,
+        }
+      )
 
       console.log('[AuthProvider] checkSession status:', response.status)
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         console.log(
           '[AuthProvider] Sesión no válida o no existente; se mantiene usuario deslogueado.'
         )
@@ -82,13 +93,12 @@ const AuthProvider = ({ children }) => {
         return
       }
 
-      const data = await response.json()
       console.log(
         '[AuthProvider] checkSession OK, usuario recuperado:',
-        data?.user
+        response.data?.user
       )
       setError(null)
-      setUser(data.user)
+      setUser(response.data.user)
       setIsLoggedIn(true)
     } catch (err) {
       if (isAbortError(err)) {

--- a/src/services/api/api.js
+++ b/src/services/api/api.js
@@ -1,16 +1,42 @@
 import axios from 'axios'
 
 // En esta rama mantenemos la URL del entorno de desarrollo puesto que la ruta del entorno de producción supone una interferencia en el login del usuario y este no puede hacer un correcto logout, Si en el entonorno de producción se genera el mismo fallo, entonces se debe actuar sobre el componente authController (logout) y ver exactamente que puede generar el fallo en producción.
-const BASE_URL = import.meta.env.VITE_API_BASE
+const DEFAULT_TIMEOUT_MS = 45000
+const rawBaseUrl = import.meta.env.VITE_API_BASE ?? ''
+const timeoutFromEnv = Number(import.meta.env.VITE_API_TIMEOUT_MS)
+
+// Normalizamos la URL base para evitar errores por espacios o barras sobrantes.
+const BASE_URL = rawBaseUrl.trim().replace(/\/$/, '')
+
+// Permitimos personalizar el timeout por entorno y usamos un valor alto por defecto
+// para tolerar el cold-start del backend en plataformas serverless.
+const REQUEST_TIMEOUT_MS = Number.isFinite(timeoutFromEnv)
+  ? timeoutFromEnv
+  : DEFAULT_TIMEOUT_MS
 
 const api = axios.create({
   baseURL: BASE_URL, // Utilizamos
   withCredentials: true,
-  timeout: 15000,
+  timeout: REQUEST_TIMEOUT_MS,
   headers: {
     'Content-Type': 'application/json',
     Accept: 'application/json',
   },
 })
+
+// Añadimos telemetría mínima para diagnosticar timeouts y errores de conexión.
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error?.code === 'ECONNABORTED') {
+      console.error(
+        `[API] Timeout excedido (${REQUEST_TIMEOUT_MS} ms):`,
+        error.config?.url
+      )
+    }
+
+    return Promise.reject(error)
+  }
+)
 
 export default api

--- a/src/services/api/authController.js
+++ b/src/services/api/authController.js
@@ -33,7 +33,16 @@ export const login = async (email, password) => {
     )
     return response.data
   } catch (error) {
+    const isTimeout = error?.code === 'ECONNABORTED'
+
     console.error('Error en login:', error.response?.data || error.message)
+
+    if (isTimeout) {
+      throw new Error(
+        'El servidor tardó demasiado en responder. Intenta nuevamente en unos segundos.'
+      )
+    }
+
     throw error
   }
 }


### PR DESCRIPTION
### Motivation
- Resolver fallos de login y validación de sesión causados por timeouts, cold-start del backend y diferencias en la configuración del cliente HTTP.
- Evitar errores por `VITE_API_BASE` mal normalizada (espacios o barra final) que pueden romper las requests hacia el backend.
- Unificar el cliente usado para la validación de sesión para asegurar comportamiento consistente con cookies y timeouts.

### Description
- Actualizado `src/services/api/api.js` para normalizar `VITE_API_BASE`, permitir `VITE_API_TIMEOUT_MS` (default `45000` ms) y usar ese timeout en el cliente Axios, además de añadir un interceptor que loguea `ECONNABORTED` para diagnosticar timeouts.
- Modificado `src/context/AuthContext/AuthProvider.jsx` para usar el cliente `api` (Axios) en la llamada de refresh de sesión (`/auth/refresh-token`), introducir `VITE_SESSION_TIMEOUT_MS` (default `25000` ms) para controlar el abort timeout y leer la respuesta usando `response.data.user`.
- Mejorado `src/services/api/authController.js` para detectar `ECONNABORTED` durante `login` y lanzar un error amistoso al usuario cuando el backend tarda demasiado en responder.

### Testing
- Ejecutado `npm run build` y la compilación con Vite completó correctamente sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10935006c832098ad1398ec4fc834)