### PR TITLE
Fix AuthProvider session validation request and error logging

### DIFF
--- a/src/context/AuthContext/AuthProvider.jsx
+++ b/src/context/AuthContext/AuthProvider.jsx
@@ -14,6 +14,7 @@ const AuthProvider = ({ children }) => {
   const API_BASE = import.meta.env.VITE_API_BASE
   const SESSION_TIMEOUT_MS = Number(import.meta.env.VITE_SESSION_TIMEOUT_MS) || 25000
   const ABORT_REASON = 'Validación de sesión cancelada por timeout.'
+  const SESSION_VALIDATION_ENDPOINT = '/auth/validate-token'
 
   // Normaliza la detección de cancelaciones para que los abortos esperados no rompan el flujo de autenticación.
   const isAbortError = (error) => {
@@ -22,6 +23,25 @@ const AuthProvider = ({ children }) => {
       error?.message === ABORT_REASON ||
       error === ABORT_REASON
     )
+  }
+
+  // Convierte cualquier error desconocido en un objeto serializable para depuración consistente.
+  const getReadableError = (err) => {
+    if (!err) {
+      return {
+        name: 'UnknownError',
+        message: 'Error desconocido durante la validación de sesión.',
+      }
+    }
+
+    return {
+      name: err?.name || 'UnknownError',
+      message: err?.message || 'Sin mensaje de error disponible.',
+      code: err?.code,
+      status: err?.response?.status,
+      responseData: err?.response?.data,
+      stack: err?.stack,
+    }
   }
 
   const login = (userData) => {
@@ -67,15 +87,15 @@ const AuthProvider = ({ children }) => {
         return
       }
 
-      const refreshUrl = '/auth/refresh-token'
+      // Validamos la sesión contra el endpoint oficial para evitar discrepancias entre entornos.
+      const refreshUrl = SESSION_VALIDATION_ENDPOINT
       console.log('[AuthProvider] Iniciando checkSession:', {
         refreshUrl,
         timeout: SESSION_TIMEOUT_MS,
       })
 
-      const response = await api.post(
+      const response = await api.get(
         refreshUrl,
-        {},
         {
           signal: controller.signal,
           withCredentials: true,
@@ -109,11 +129,9 @@ const AuthProvider = ({ children }) => {
         return
       }
 
-      console.error('[AuthProvider] Error al validar sesión:', {
-        name: err?.name,
-        message: err?.message,
-        stack: err?.stack,
-      })
+      const readableError = getReadableError(err)
+
+      console.error('[AuthProvider] Error al validar sesión:', readableError)
 
       // No bloqueamos el modal de auth con una pantalla de error global: degradamos a estado deslogueado.
       setError(null)


### PR DESCRIPTION
### Motivation
- Resolver que el backend no reciba la acción de validación de sesión porque el proveedor de autenticación estaba usando la ruta/método incorrecto y los logs eran difíciles de depurar.
- Alinear la verificación inicial de sesión con el contrato de la API usado en el resto del frontend para evitar discrepancias entre entornos.

### Description
- Cambiado `AuthProvider.checkSession` para validar la sesión contra `SESSION_VALIDATION_ENDPOINT` (`/auth/validate-token`) en lugar de la ruta previa, y usar `GET` en vez de `POST` para alinear con `authController`.
- Introducido el constante `SESSION_VALIDATION_ENDPOINT` para evitar rutas hardcodeadas dispersas en el código.
- Añadido el helper `getReadableError` que normaliza errores de Axios en un objeto serializable con `status`, `responseData`, `code` y `stack` para mejorar el logging en `checkSession`.
- Conservada la degradación suave: cuando la validación falla el usuario permanece deslogueado y la UI de login no queda bloqueada.

### Testing
- Ejecutado `npm run build` en el proyecto y la compilación de Vite finalizó correctamente sin errores.
- No se añadieron tests unitarios; la validación se probó mediante la build de producción que pasó satisfactoriamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10dabf3ec8320ad4ea5e369676541)