### PR TITLE
fix(auth): evitar falsos positivos por cancelación en validate-token

### DIFF
--- a/src/context/AuthContext/AuthProvider.jsx
+++ b/src/context/AuthContext/AuthProvider.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
+import axios from 'axios'
 import { login as loginRequest, logout } from '@/services/api/authController'
 import { AuthContext } from './AuthContext'
 import { useNavigate } from 'react-router-dom'
@@ -12,14 +13,17 @@ const AuthProvider = ({ children }) => {
   const navigate = useNavigate()
 
   const API_BASE = import.meta.env.VITE_API_BASE
-  const SESSION_TIMEOUT_MS = Number(import.meta.env.VITE_SESSION_TIMEOUT_MS) || 25000
+  const SESSION_TIMEOUT_MS = Number(import.meta.env.VITE_SESSION_TIMEOUT_MS) || 45000
   const ABORT_REASON = 'Validación de sesión cancelada por timeout.'
   const SESSION_VALIDATION_ENDPOINT = '/auth/validate-token'
 
   // Normaliza la detección de cancelaciones para que los abortos esperados no rompan el flujo de autenticación.
   const isAbortError = (error) => {
     return (
+      axios.isCancel(error) ||
       error?.name === 'AbortError' ||
+      error?.name === 'CanceledError' ||
+      error?.code === 'ERR_CANCELED' ||
       error?.message === ABORT_REASON ||
       error === ABORT_REASON
     )


### PR DESCRIPTION
### Motivation
- Evitar que la validación de sesión (`/auth/validate-token`) reporte errores cuando la petición se cancela por timeout o por mecanismos de Axios (p. ej. cold-start del backend) debido a un timeout local corto y detección incompleta de cancelaciones.

### Description
- Se importó `axios`, se elevó el timeout por defecto de `checkSession` a `45000` ms y se amplió `isAbortError` para contemplar `axios.isCancel(error)`, `CanceledError` y `ERR_CANCELED` para normalizar cancelaciones esperadas.

### Testing
- Se ejecutó la construcción de producción con `npm run build` y finalizó correctamente (build exitoso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10f75709c8320abcc34242533189d)