### PR TITLE
fix: centralizar manejo CSRF para logout y mutaciones de perfil

### DIFF
--- a/src/services/api/api.js
+++ b/src/services/api/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
+import { clearCsrfToken, ensureCsrfToken, isMutationMethod } from './csrf'
 
-// En esta rama mantenemos la URL del entorno de desarrollo puesto que la ruta del entorno de producción supone una interferencia en el login del usuario y este no puede hacer un correcto logout, Si en el entonorno de producción se genera el mismo fallo, entonces se debe actuar sobre el componente authController (logout) y ver exactamente que puede generar el fallo en producción.
 const DEFAULT_TIMEOUT_MS = 45000
 const rawBaseUrl = import.meta.env.VITE_API_BASE ?? ''
 const timeoutFromEnv = Number(import.meta.env.VITE_API_TIMEOUT_MS)
@@ -15,7 +15,7 @@ const REQUEST_TIMEOUT_MS = Number.isFinite(timeoutFromEnv)
   : DEFAULT_TIMEOUT_MS
 
 const api = axios.create({
-  baseURL: BASE_URL, // Utilizamos
+  baseURL: BASE_URL,
   withCredentials: true,
   timeout: REQUEST_TIMEOUT_MS,
   headers: {
@@ -24,10 +24,58 @@ const api = axios.create({
   },
 })
 
-// Añadimos telemetría mínima para diagnosticar timeouts y errores de conexión.
+// Adjuntamos CSRF en todas las mutaciones para soportar entornos cross-site.
+api.interceptors.request.use(async (config) => {
+  if (!isMutationMethod(config.method)) {
+    return config
+  }
+
+  const hasCsrfHeader =
+    config.headers?.['x-csrf-token'] ||
+    config.headers?.['X-CSRF-Token'] ||
+    config.headers?.['x-xsrf-token'] ||
+    config.headers?.['X-XSRF-TOKEN']
+
+  if (hasCsrfHeader) {
+    return config
+  }
+
+  const csrfToken = await ensureCsrfToken(api)
+
+  if (csrfToken) {
+    config.headers = {
+      ...config.headers,
+      'x-csrf-token': csrfToken,
+    }
+  }
+
+  return config
+})
+
+// Reintentamos una sola vez si el backend rechaza por CSRF para renovar token automáticamente.
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
+  async (error) => {
+    const originalRequest = error?.config
+    const isCsrfError =
+      error?.response?.status === 403 &&
+      typeof error?.response?.data?.message === 'string' &&
+      error.response.data.message.toLowerCase().includes('csrf')
+
+    if (isCsrfError && originalRequest && !originalRequest._csrfRetried) {
+      originalRequest._csrfRetried = true
+      clearCsrfToken()
+      const freshToken = await ensureCsrfToken(api, true)
+
+      if (freshToken) {
+        originalRequest.headers = {
+          ...originalRequest.headers,
+          'x-csrf-token': freshToken,
+        }
+        return api.request(originalRequest)
+      }
+    }
+
     if (error?.code === 'ECONNABORTED') {
       console.error(
         `[API] Timeout excedido (${REQUEST_TIMEOUT_MS} ms):`,

--- a/src/services/api/authController.js
+++ b/src/services/api/authController.js
@@ -1,22 +1,14 @@
 import api from './api'
-import axios from 'axios'
+import { clearCsrfToken } from './csrf'
 
-const API_BASE = import.meta.env.VITE_API_BASE
 /**
- * Inicia sesión enviando credenciales al backend.
- * @param {string} email - Correo del usuario.
- * @param {string} password - Contraseña del usuario.
- * @returns {Promise<object>} - Respuesta con los datos del usuario autenticado.
+ * Cierra la sesión del usuario autenticado.
+ * @returns {Promise<boolean>} true cuando el backend cierra sesión correctamente.
  */
 export const logout = async () => {
   try {
-    const response = await axios.post(
-      `${API_BASE.replace(/\/$/, '')}/auth/logout`,
-      {},
-      {
-        withCredentials: true,
-      }
-    )
+    const response = await api.post('/auth/logout', {}, { withCredentials: true })
+    clearCsrfToken()
     return response.status === 200
   } catch (error) {
     console.error('Logout fallido:', error)
@@ -24,6 +16,12 @@ export const logout = async () => {
   }
 }
 
+/**
+ * Inicia sesión enviando credenciales al backend.
+ * @param {string} email - Correo del usuario.
+ * @param {string} password - Contraseña del usuario.
+ * @returns {Promise<object>} Respuesta con los datos del usuario autenticado.
+ */
 export const login = async (email, password) => {
   try {
     const response = await api.post(
@@ -46,15 +44,13 @@ export const login = async (email, password) => {
     throw error
   }
 }
+
 /**
  * Obtiene la sesión del usuario autenticado desde el backend.
- * @returns {Promise<object|null>} - Datos del usuario o null si no está autenticado.
+ * @returns {Promise<object|null>} Datos del usuario o null si no está autenticado.
  */
 export const getUserSession = async () => {
   try {
-    // Validar sesión siempre contra el backend.
-    // Esto evita falsos negativos cuando la cookie de sesión es HttpOnly
-
     const response = await api.get('/auth/validate-token', {
       withCredentials: true,
     })
@@ -68,7 +64,7 @@ export const getUserSession = async () => {
 
     if (error.response?.status === 401) {
       console.warn('Token inválido o no proporcionado, sesión no iniciada.')
-      return null // NO ejecutar logout si simplemente no hay sesión activa
+      return null
     }
 
     return null

--- a/src/services/api/csrf.js
+++ b/src/services/api/csrf.js
@@ -1,0 +1,108 @@
+const CSRF_COOKIE_NAME = 'XSRF-TOKEN'
+const DEFAULT_CSRF_ENDPOINT = '/auth/csrf-token'
+
+// Conservamos el token en memoria para evitar pedirlo en cada request mutante.
+let cachedCsrfToken = null
+let pendingCsrfRequest = null
+
+// Lee una cookie del documento cuando el navegador permite acceso (mismo dominio o dominio compartido).
+const readCookieValue = (cookieName) => {
+  if (typeof document === 'undefined' || typeof document.cookie !== 'string') {
+    return null
+  }
+
+  const cookieEntry = document.cookie
+    .split(';')
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(`${cookieName}=`))
+
+  if (!cookieEntry) {
+    return null
+  }
+
+  return decodeURIComponent(cookieEntry.slice(cookieName.length + 1))
+}
+
+// Intenta resolver el token CSRF desde las posibles formas de respuesta del backend.
+const getTokenFromPayload = (payload) => {
+  if (!payload) {
+    return null
+  }
+
+  if (typeof payload === 'string' && payload.trim().length > 0) {
+    return payload.trim()
+  }
+
+  if (typeof payload === 'object') {
+    const directToken = payload.csrfToken || payload.token
+    if (typeof directToken === 'string' && directToken.trim().length > 0) {
+      return directToken.trim()
+    }
+
+    const nestedToken = payload.data?.csrfToken || payload.data?.token
+    if (typeof nestedToken === 'string' && nestedToken.trim().length > 0) {
+      return nestedToken.trim()
+    }
+  }
+
+  return null
+}
+
+// Permite configurar el endpoint de emisión de CSRF sin acoplarlo al código.
+const getCsrfEndpoint = () => {
+  const configuredEndpoint = import.meta.env.VITE_CSRF_ENDPOINT
+  return (configuredEndpoint || DEFAULT_CSRF_ENDPOINT).trim()
+}
+
+// Solicita un token CSRF nuevo al backend y lo guarda en caché de memoria.
+export const fetchCsrfToken = async (apiClient) => {
+  const endpoint = getCsrfEndpoint()
+
+  if (!endpoint) {
+    return null
+  }
+
+  const response = await apiClient.get(endpoint, {
+    withCredentials: true,
+  })
+
+  const responseToken = getTokenFromPayload(response?.data)
+  const cookieToken = readCookieValue(CSRF_COOKIE_NAME)
+  const resolvedToken = responseToken || cookieToken
+
+  cachedCsrfToken = resolvedToken || null
+  return cachedCsrfToken
+}
+
+// Obtiene token CSRF reutilizable; si no existe, lo solicita una única vez concurrente.
+export const ensureCsrfToken = async (apiClient, forceRefresh = false) => {
+  if (!forceRefresh && cachedCsrfToken) {
+    return cachedCsrfToken
+  }
+
+  if (!forceRefresh) {
+    const cookieToken = readCookieValue(CSRF_COOKIE_NAME)
+    if (cookieToken) {
+      cachedCsrfToken = cookieToken
+      return cachedCsrfToken
+    }
+  }
+
+  if (!pendingCsrfRequest || forceRefresh) {
+    pendingCsrfRequest = fetchCsrfToken(apiClient).finally(() => {
+      pendingCsrfRequest = null
+    })
+  }
+
+  return pendingCsrfRequest
+}
+
+// Limpia el token en memoria para obligar una renovación tras logout o errores CSRF.
+export const clearCsrfToken = () => {
+  cachedCsrfToken = null
+}
+
+// Determina si un método HTTP requiere validación CSRF del backend.
+export const isMutationMethod = (method) => {
+  return ['post', 'put', 'patch', 'delete'].includes((method || '').toLowerCase())
+}


### PR DESCRIPTION
### Motivation
- El backend en producción aplica validación CSRF en rutas mutantes (`/auth/logout`, `/auth/profile/*`) y las peticiones frontend fallaban con `403` por ausencia o caducidad del token CSRF. 
- Se buscó un manejo consistente del token CSRF en el cliente para evitar usar distintos clients (`axios` vs `api`) y para soportar entornos cross-site.

### Description
- Se añadió `src/services/api/csrf.js` que implementa obtención, resolución desde payload o cookie, cache en memoria, renovación concurrente y helpers (`ensureCsrfToken`, `fetchCsrfToken`, `clearCsrfToken`, `isMutationMethod`).
- Se actualizó `src/services/api/api.js` para adjuntar automáticamente `x-csrf-token` en solicitudes mutantes (`POST/PUT/PATCH/DELETE`) y para reintentar una vez tras un `403` por CSRF renovando el token antes del retry.
- Se modificó `src/services/api/authController.js` para usar el cliente compartido `api` en `logout` y para limpiar el token en memoria con `clearCsrfToken()` tras cerrar sesión.
- El endpoint CSRF es configurable vía `VITE_CSRF_ENDPOINT` con fallback a `/auth/csrf-token` y la cookie usada como fallback es `XSRF-TOKEN`.

### Testing
- Se ejecutó `npm run build` y la compilación de producción con `vite` finalizó correctamente sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a131c9a6108320a6385cc1df7b5fb6)